### PR TITLE
mod_stat bug fix

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -1,3 +1,9 @@
+## V1.1b
+### CHANGES
+ - Fixed mod_stat analysis option bug, when CAN Frame has 1 byte size
+ - Default sniff config added
+
+
 ## V1.0b
 ### CHANGES
 First Beta

--- a/examples/can_sniff.py
+++ b/examples/can_sniff.py
@@ -1,0 +1,10 @@
+load_modules = {
+    'hw_USBtin':    {'port':'auto', 'debug':1, 'speed':500},  # IO hardware module                           # Module for sniff and replay
+    'mod_stat':    {}                                         # Stats
+}
+
+# Now let's describe the logic of this test
+actions = [
+    {'hw_USBtin':   {'action': 'read','pipe': 1}},   # Read to PIPE 1
+    {'mod_stat':    {'pipe': 1}}   # Write generated packets (pings)
+    ]

--- a/modules/mod_stat.py
+++ b/modules/mod_stat.py
@@ -82,6 +82,8 @@ class mod_stat(CANModule):
         for fid, lst in self._bodyList.iteritems():
             message_iso = ISOTPMessage(fid)
             for (lenX, msg, bus, mod), cnt in lst.iteritems():
+                if lenX < 2:
+                    continue
                 ret = message_iso.add_can(CANMessage.init_data(fid, len(msg), [struct.unpack("B", x)[0] for x in msg])) # TODO NEED RET?
                 #if ret < 0 or message_iso.message_length < 1:
                 #     message_iso = ISOTPMessage(fid)


### PR DESCRIPTION
- Fixed mod_stat analysis option bug, when CAN Frame has 1 byte size
- Default sniff config added