### PR TITLE
Implement self-documented module command

### DIFF
--- a/cantoolz.py
+++ b/cantoolz.py
@@ -158,8 +158,8 @@ class WebConsole(http.server.SimpleHTTPRequestHandler):
                 try:
                     help_list = self.can_engine.get_modules_list()[self.can_engine.find_module(str(path_parts[3]))][1]._cmdList
                     response_help = collections.OrderedDict()
-                    for cmd, body in help_list.items():
-                        response_help[cmd] = {'descr': body[0], 'descr_param': body[2], 'param_count': body[1]}
+                    for key, cmd in help_list.items():
+                        response_help[key] = {'descr': cmd.description, 'descr_param': cmd.desc_params, 'param_count': cmd.num_params}
                     body = json.dumps(response_help, ensure_ascii=False)
                     resp_code = 200
                 except Exception as e:
@@ -189,8 +189,8 @@ class WebConsole(http.server.SimpleHTTPRequestHandler):
                     modz3 = {}
                     for name, module, params in modz2:
                         btns = {}
-                        for btn, bdy in module._cmdList.items():
-                            btns[btn] = bdy[4]
+                        for key, cmd in module._cmdList.items():
+                            btns[key] = cmd.is_enabled
                         modz3[name] = {"bar": module.get_status_bar(), "status": module.is_active, "buttons":btns}
                     body = json.dumps({"status": modz, "progress": modz3})
                     resp_code = 200
@@ -390,8 +390,8 @@ class UserInterface:
                         mod  = self.CANEngine.get_modules_list()[module][1]
                         print(("\nModule " + mod.__class__.__name__ + ": " + mod.name + "\n" + mod.help + \
                             "\n\nConsole commands:\n"))
-                        for cmd, dat in mod._cmdList.items():
-                            print(("\t" + cmd + " " + dat[2] + "\t\t - " + dat[0] + "\n"))
+                        for key, cmd in mod._cmdList.items():
+                            print(("\t" + key + " " + cmd.desc_params + "\t\t - " + cmd.description + "\n"))
                     except Exception as e:
                         print(("Help error: " + str(e)))
                 else:

--- a/cantoolz/module.py
+++ b/cantoolz/module.py
@@ -1,103 +1,196 @@
+"""
+Generic class for modules
+"""
+
 import threading
 import collections
 import codecs
-'''
-Generic class for modules
-'''
 
 
-# Generic class for all modules
+class Command(object):
+
+    """Command class helper to easily identify command attributes."""
+
+    def __init__(self, description, num_params, desc_params, callback, is_enabled, index=0):
+        #: Description of what the command does.
+        self.description = description
+        #: Number of parameters.
+        self.num_params = num_params
+        #: Description of the parameters if any.
+        self.desc_params = desc_params
+        #: Function to call when executing the command.
+        self.callback = callback
+        #: Command is enabled (or not).
+        self.is_enabled = is_enabled
+        #: index
+        self.index = index
+
+
 class CANModule:
-    name = "Abstract CANSploit module"
-    help = "No help available"
-    id = 0
-    version = 0.0
 
-    _active = True  # Enabled/Disabled
+    """Generic class for all modules.
+
+    Defines all default behaviors that must/should be overriden by other modules.
+    """
+
+    #: Name of the module.
+    name = 'Abstract CANSploit module'
+    #: Help of the module (can be multiline).
+    help = 'No help available'
+    #: ID of the module.
+    id = 0
+    #: Version of the module.
+    version = 0.0
+    #: Debug flag for verbose output.
+    DEBUG = 0
+
+    _active = True  # True if module is enabled. False otherwise.
+    _timeout = 3  # Maximum timeout value when running thread
     thr_block = threading.Event()  # Blocking mode (using events)
+
+    def __init__(self, params):
+        """Initialize the module.
+
+        :param dict param: Parameters of the module.
+        """
+        self.DEBUG = int(params.get('debug', 0))
+        self._bus = params.get('bus', self.__class__.__name__)
+        self._active = False if params.get('active') in ["False", "false", "0", "-1"] else True
+        # List of default commands supported by the module.
+        self._cmdList = collections.OrderedDict()  # Command list (doInit section)
+        self._cmdList['S'] = Command('Current status', 0, '', self.get_status, True)
+        self._cmdList['s'] = Command('Stop/Activate current module', 0, '', self.do_activate, True)
+        self._status = 0
+        self.do_init(params)
 
     @staticmethod
     def get_hex(bytes_in):
+        """Get hexadecimal representation of `bytes_in`."""
         return (codecs.encode(bytes_in, 'hex_codec')).decode("ISO-8859-1")
 
     @property
     def is_active(self):
+        """Module is active or not.
+
+        :returns: boolean -- `True` if module is active, `False` otherwise.
+        """
         return self._active
 
-    def get_status(self, def_in = 0):
-        return "Current status: " + str(self._active)
+    def get_status(self, def_in=0):
+        """Human-representation of the module status.
 
-    def do_activate(self, def_in = 0, mode = -1):
+        :returns: str -- Human-readable status of the module.
+        """
+        return 'Current status: {0}'.format(self._active)
+
+    def do_activate(self, def_in=0, mode=-1):
+        """Force the status of the module to `mode`.
+
+        :param int mode: Mode the module should be switched to (default: `-1`)
+          - `0` module is switched off
+          - `-1` module is switched to the opposite of its current state (active -> inactive / inactive -> active)
+          - else module is switched on
+
+        :returns: str -- Human-readable status of the module.
+        """
         if mode == -1:
             self._active = not self._active
         elif mode == 0:
             self._active = False
         else:
             self._active = True
-        return "Active status: " + str(self._active)
+        return 'Active status: {0}'.format(self._active)
 
     def dprint(self, level, msg):
-        str_msg = self.__class__.__name__ + ": " + msg
+        """Print function for debugging purpose."""
+        str_msg = '{0}: {1}'.format(self.__class__.__name__, msg)
         if level <= self.DEBUG:
             print(str_msg)
 
     def raw_write(self, string):  # Used for direct input
-        ret = ""
-        self.thr_block.wait(3)
+        """Call the command specified in `string` and return its result.
+
+        :param str string: The full command with its paramaters (e.g. 's' to stop the module)
+
+        :returns: str -- Result of the command execution.
+        """
+        ret = ''
+        self.thr_block.wait(timeout=self._timeout)  # Timeout of 3 seconds
         self.thr_block.clear()
-        in_cmd = string.lstrip().split(" ")[0]
-        lost_cmd = None
-        if len(string.lstrip().split(" ")) > 1:
-            lost_cmd = ' '.join(string.lstrip().split(" ")[1:])
+        full_cmd = string.lstrip()
+        if ' ' in full_cmd:  # Any parameters specified?
+            in_cmd, parameters = full_cmd.split(' ', maxsplit=1)
+        else:
+            in_cmd = full_cmd
+            parameters = None
         if in_cmd in self._cmdList:
             cmd = self._cmdList[in_cmd]
-            if cmd[4]:
-                if len(cmd) == 5:
-                    cmd.append(0)
-                if lost_cmd:
-                    ret = cmd[3](cmd[5], lost_cmd)
+            if cmd.is_enabled:
+                if parameters:
+                    ret = cmd.callback(cmd.index, parameters)
                 else:
-                    ret = cmd[3](cmd[5])
+                    ret = cmd.callback(cmd.index)
             else:
-                ret = "Error: command is disabled!"
+                ret = 'Error: command is disabled!'
         self.thr_block.set()
         return ret
 
-    def do_effect(self, can_msg, args):  # Effect (could be fuzz operation, sniff, filter or whatever)
+    def do_effect(self, can_msg, args):
+        """Function to override when implementing an effect (fuzzing, sniffer, filtering operations, etc.)
+
+        :returns: str -- CAN message after effect has been applied.
+        """
         return can_msg
 
     def get_name(self):
+        """Get the name of the module.
+
+        :returns: str -- Name of the module.
+        """
         return self.name
 
     def get_help(self):
+        """Get the help of the module.
+
+        :returns: str -- Help of the module.
+        """
         return self._cmdList
 
-    def __init__(self, params):
-
-        self.DEBUG = int(params.get('debug', 0))
-        self._bus = params.get('bus', self.__class__.__name__)
-        self._active = False if params.get('active') in ["False", "false", "0", "-1"] else True
-        self._cmdList = collections.OrderedDict()  # Command list (doInit section)
-        self._cmdList['S'] = ["Current status", 0, "", self.get_status, True]
-        self._cmdList['s'] = ["Stop/Activate current module", 0, "", self.do_activate, True]
-        self._status = 0
-        self.do_init(params)
-
     def get_status_bar(self):
-        self.thr_block.wait(3)
+        """Get the status of the module.
+
+        :returns: int -- Status of the module.
+        """
+        self.thr_block.wait(timeout=self._timeout)
         self.thr_block.clear()
         status = int(self._status)
         self.thr_block.set()
         return status
 
-    def do_init(self, params):  # Call for some pre-calculation
+    def do_init(self, params):
+        """Function to perform calculations before doing any actual work.
+
+        :returns: int -- Status of init.
+        """
         return 0
 
-    def do_stop(self, params):  # Stop activity of this module
+    def do_stop(self, params):
+        """Function called when stopping activity of the module.
+
+        :returns: int -- Status of stop.
+        """
         return 0
 
-    def do_start(self, params):  # Start activity of this module
+    def do_start(self, params):
+        """Function called when starting activity of the module.
+
+        :returns: int -- Status of start.
+        """
         return 0
 
     def do_exit(self, params):
+        """Function called when exiting activity of the module.
+
+        :returns: int -- Status of exit.
+        """
         return 0

--- a/cantoolz/modules/can_controls.py
+++ b/cantoolz/modules/can_controls.py
@@ -53,7 +53,7 @@ class can_controls(CANModule):
                     cmd_list.remove(cmd)
             else:
                 cmd = cmd_list.pop()
-            self._cmdList[cmd] = ["Action: " + list([x for x in list(command.keys()) if  x not in ["cmd"]])[0],0,'', self.send_command, True, index]
+            self._cmdList[cmd] = Command('Action: ' + list([x for x in list(command.keys()) if  x not in ['cmd']])[0], 0, '', self.send_command, True, index)
             index += 1
         index = 0
         for status in self._statuses:
@@ -63,7 +63,7 @@ class can_controls(CANModule):
                     cmd_list.remove(cmd)
             else:
                 cmd = cmd_list.pop()
-            self._cmdList[cmd] = ["Status: " + list([x for x in list(status.keys()) if  x not in ["id_list_can_toolz_system","cmd","current_status"]])[0],0,'', self.get_statuses, True, index]
+            self._cmdList[cmd] = Command("Status: " + list([x for x in list(status.keys()) if  x not in ["id_list_can_toolz_system","cmd","current_status"]])[0],0,'', self.get_statuses, True, index)
             index += 1
             fid_list = []
             for name, data in status.items():

--- a/cantoolz/modules/control_ecu_doors.py
+++ b/cantoolz/modules/control_ecu_doors.py
@@ -32,9 +32,9 @@ class control_ecu_doors(CANModule):
         self._status2 = params
         self.frames = []
         self._doors = {}
-        self._cmdList['status'] = ["Get doors status", 0, "", self.control_get_status, True]
-        self._cmdList['central_lock'] = ["Lock doors", 0, "", self.control_lock, True]
-        self._cmdList['central_unlock'] = ["Unlock doors", 0, "", self.control_unlock, True]
+        self._cmdList['status'] = Command("Get doors status", 0, "", self.control_get_status, True)
+        self._cmdList['central_lock'] = Command("Lock doors", 0, "", self.control_lock, True)
+        self._cmdList['central_unlock'] = Command("Unlock doors", 0, "", self.control_unlock, True)
 
     def control_lock(self, flag):
         self.frames.append(CANMessage(self._status2['id_command'],int(len(self._status2['commands']['lock'])/2),bytes.fromhex(self._status2['commands']['lock']),False, CANMessage.DataFrame))

--- a/cantoolz/modules/control_ecu_engine.py
+++ b/cantoolz/modules/control_ecu_engine.py
@@ -37,11 +37,11 @@ class control_ecu_engine(CANModule):
         self.rpm_down = 0
         self.frames = []
 
-        self._cmdList['status'] = ["Get engine status", 0, "", self.control_get_status, True]
-        self._cmdList['rpmup'] = ["Increase RMP", 0, "", self.control_rpm_up, True]
-        self._cmdList['rpmdw'] = ["Decrease RMP", 0, "", self.control_rpm_down, True]
-        self._cmdList['start'] = ["Start engine", 0, "", self.control_start_engine, True]
-        self._cmdList['stop'] = ["Stop engine", 0, "", self.control_stop_engine, True]
+        self._cmdList['status'] = Command("Get engine status", 0, "", self.control_get_status, True)
+        self._cmdList['rpmup'] = Command("Increase RMP", 0, "", self.control_rpm_up, True)
+        self._cmdList['rpmdw'] = Command("Decrease RMP", 0, "", self.control_rpm_down, True)
+        self._cmdList['start'] = Command("Start engine", 0, "", self.control_start_engine, True)
+        self._cmdList['stop'] = Command("Stop engine", 0, "", self.control_stop_engine, True)
 
     def control_rpm_up(self, flag):
         self.frames.append(CANMessage(self._status2['id_command'],2,bytes.fromhex(self._status2['commands']['rpm_up'] + '20'),False, CANMessage.DataFrame))

--- a/cantoolz/modules/control_ecu_lights.py
+++ b/cantoolz/modules/control_ecu_lights.py
@@ -33,10 +33,10 @@ class control_ecu_lights(CANModule):
         self._status2 = params
         self.frames = []
         self._doors = {}
-        self._cmdList['status'] = ["Get lights status", 0, "", self.control_get_status, True]
-        self._cmdList['off'] = ["Lights OFF", 0, "", self.lights_off, True]
-        self._cmdList['on'] = ["Lights ON", 0, "", self.lights_on, True]
-        self._cmdList['distance'] = ["Disatnace lights on", 0, "", self.dlights_on, True]
+        self._cmdList['status'] = Command("Get lights status", 0, "", self.control_get_status, True)
+        self._cmdList['off'] = Command("Lights OFF", 0, "", self.lights_off, True)
+        self._cmdList['on'] = Command("Lights ON", 0, "", self.lights_on, True)
+        self._cmdList['distance'] = Command("Disatnace lights on", 0, "", self.dlights_on, True)
 
     def lights_off(self, flag):
         self.frames.append(CANMessage(self._status2['id_command'],int(len(self._status2['commands']['off'])/2),bytes.fromhex(self._status2['commands']['off']),False, CANMessage.DataFrame))

--- a/cantoolz/modules/ecu_controls.py
+++ b/cantoolz/modules/ecu_controls.py
@@ -53,7 +53,7 @@ class ecu_controls(CANModule):
                     cmd_list.remove(cmd)
             else:
                 cmd = cmd_list.pop()
-            self._cmdList[cmd] = ["Action: " + list([x for x in list(command.keys()) if  x not in ["cmd"]])[0],0,'', self.send_command, True, index]
+            self._cmdList[cmd] = Command("Action: " + list([x for x in list(command.keys()) if  x not in ["cmd"]])[0],0,'', self.send_command, True, index)
             index += 1
         index = 0
         for status in self._statuses:
@@ -63,7 +63,7 @@ class ecu_controls(CANModule):
                     cmd_list.remove(cmd)
             else:
                 cmd = cmd_list.pop()
-            self._cmdList[cmd] = ["Status: " + list([x for x in list(status.keys()) if  x not in ["id_list_can_toolz_system","cmd","current_status"]])[0],0,'', self.get_statuses, True, index]
+            self._cmdList[cmd] = Command("Status: " + list([x for x in list(status.keys()) if  x not in ["id_list_can_toolz_system","cmd","current_status"]])[0],0,'', self.get_statuses, True, index)
             index += 1
             fid_list = []
             for name, data in status.items():

--- a/cantoolz/modules/gen_replay.py
+++ b/cantoolz/modules/gen_replay.py
@@ -54,12 +54,12 @@ class gen_replay(CANModule):
         if 'load_from' in params:
             self.cmd_load(0, params['load_from'])
 
-        self._cmdList['g'] = ["Enable/Disable sniff mode to collect packets", 0, "", self.sniff_mode, True]
-        self._cmdList['p'] = ["Print count of loaded packets", 0, "", self.cnt_print, True]
-        self._cmdList['l'] = ["Load packets from file", 1, " <file> ", self.cmd_load, True]
-        self._cmdList['r'] = ["Replay range from loaded, from number X to number Y", 1, " <X>-<Y> ", self.replay_mode, True]
-        self._cmdList['d'] = ["Save range of loaded packets, from X to Y", 1, " <X>-<Y>, <filename>",self.save_dump, True]
-        self._cmdList['c'] = ["Clean loaded table", 0, "", self.clean_table, True]
+        self._cmdList['g'] = Command("Enable/Disable sniff mode to collect packets", 0, "", self.sniff_mode, True)
+        self._cmdList['p'] = Command("Print count of loaded packets", 0, "", self.cnt_print, True)
+        self._cmdList['l'] = Command("Load packets from file", 1, " <file> ", self.cmd_load, True)
+        self._cmdList['r'] = Command("Replay range from loaded, from number X to number Y", 1, " <X>-<Y> ", self.replay_mode, True)
+        self._cmdList['d'] = Command("Save range of loaded packets, from X to Y", 1, " <X>-<Y>, <filename>",self.save_dump, True)
+        self._cmdList['c'] = Command("Clean loaded table", 0, "", self.clean_table, True)
 
 
     def clean_table(self, def_in):
@@ -90,12 +90,12 @@ class gen_replay(CANModule):
 
         if self._sniff:
             self._sniff = False
-            self._cmdList['r'][4] = True
-            self._cmdList['d'][4] = True
+            self._cmdList['r'].is_enabled = True
+            self._cmdList['d'].is_enabled = True
         else:
             self._sniff = True
-            self._cmdList['r'][4] = False
-            self._cmdList['d'][4] = False
+            self._cmdList['r'].is_enabled = False
+            self._cmdList['d'].is_enabled = False
             self.CANList.restart_time()
         return str(self._sniff)
 
@@ -112,7 +112,7 @@ class gen_replay(CANModule):
                 self._replay = True
                 self._full = self._num2 - self._num1
                 self._last = 0
-                self._cmdList['g'][4] =  False
+                self._cmdList['g'].is_enabled =  False
                 self.CANList.set_index(self._num1)
 
 
@@ -143,10 +143,10 @@ class gen_replay(CANModule):
                 self._status = self._last/(self._full/100.0)
             except Exception as e:
                 self._replay = False
-                self._cmdList['g'][4] = True
+                self._cmdList['g'].is_enabled = True
                 self.CANList.reset()
             if self._num1 == self._num2:
                 self._replay = False
-                self._cmdList['g'][4] = True
+                self._cmdList['g'].is_enabled = True
                 self.CANList.reset()
         return can_msg

--- a/cantoolz/modules/hw_CANBusTriple.py
+++ b/cantoolz/modules/hw_CANBusTriple.py
@@ -219,8 +219,8 @@ class hw_CANBusTriple(CANModule):
         self.dprint(1, "CANBus Triple device detected, version: " + self.read_json(self.get_info())['version'])
 
 
-        self._cmdList['t'] = ["Send direct command to the device, like 02010011112233440000000008", 1, " <cmd> ",
-                              self.dev_write, True]
+        self._cmdList['t'] = Command("Send direct command to the device, like 02010011112233440000000008", 1, " <cmd> ",
+                              self.dev_write, True)
 
     def dev_write(self, def_in, data):
         self.dprint(1, "CMD: " + data)

--- a/cantoolz/modules/hw_CANSocket.py
+++ b/cantoolz/modules/hw_CANSocket.py
@@ -29,7 +29,7 @@ class hw_CANSocket(CANModule):
     def do_init(self, init_params):  # Get device and open serial port
         self.device = init_params.get('iface', None)
         self._bus = init_params.get('bus','CANSocket')
-        self._cmdList['t'] = ["Send CAN frame directly, like 01A#11223344", 1, " <frame> ", self.dev_write, True]
+        self._cmdList['t'] = Command("Send CAN frame directly, like 01A#11223344", 1, " <frame> ", self.dev_write, True)
         self._active = True
         self._run = False
 

--- a/cantoolz/modules/hw_TCP2CAN.py
+++ b/cantoolz/modules/hw_TCP2CAN.py
@@ -280,8 +280,8 @@ class hw_TCP2CAN(CANModule):
             self.server =  None
 
     def do_init(self, params):  # Get device and open serial port
-        self._cmdList['t'] = ["Send direct command to the device, like 13:8:1122334455667788", 1, " <cmd> ",
-                              self.dev_write, True]
+        self._cmdList['t'] = Command("Send direct command to the device, like 13:8:1122334455667788", 1, " <cmd> ",
+                              self.dev_write, True)
 
         self.mode = params.get('mode', None)
         self.server = None

--- a/cantoolz/modules/hw_USBtin.py
+++ b/cantoolz/modules/hw_USBtin.py
@@ -217,8 +217,8 @@ class hw_USBtin(CANModule):
         self.dprint(1, "Speed: " + str(self._currentSpeed))
         self.dprint(1, "USBtin device found!")
 
-        self._cmdList['speed'] = ["Set device speed (kBaud) and SJW level(optional)", 1, " <speed>,<SJW> ", self.set_speed, True]
-        self._cmdList['t'] = ["Send direct command to the device, like t001411223344", 1, " <cmd> ", self.dev_write, True]
+        self._cmdList['speed'] = Command("Set device speed (kBaud) and SJW level(optional)", 1, " <speed>,<SJW> ", self.set_speed, True)
+        self._cmdList['t'] = Command("Send direct command to the device, like t001411223344", 1, " <cmd> ", self.dev_write, True)
 
     def dev_write(self, def_in, data):
         self.dprint(2, "CMD: " + data + " try: " + str(def_in))

--- a/cantoolz/modules/hw_fakeIO.py
+++ b/cantoolz/modules/hw_fakeIO.py
@@ -31,8 +31,8 @@ class hw_fakeIO(CANModule):
         self.CANList = []
 
     def do_init(self, params):  # Get device and open serial port
-        self._cmdList['t'] = ["Send direct command to the device, like 13:8:1122334455667788", 1, " <cmd> ",
-                              self.dev_write, True]
+        self._cmdList['t'] = Command("Send direct command to the device, like 13:8:1122334455667788", 1, " <cmd> ",
+                              self.dev_write, True)
         self.CANList = []
         return 1
 

--- a/cantoolz/modules/mod_stat.py
+++ b/cantoolz/modules/mod_stat.py
@@ -68,41 +68,41 @@ class mod_stat(CANModule):
         if 'meta_file' in params:
             self.dprint(1, self.do_load_meta(0, params['meta_file']))
 
-        self._cmdList['p'] = ["Print current table",1, "[index]", self.do_print, True]
+        self._cmdList['p'] = Command("Print current table",1, "[index]", self.do_print, True)
 
-        self._cmdList['a'] = ["Analysis of captured traffic", 1, "<UDS|ISO|FRAG|ALL(defaut)>,[buffer index]", self.do_anal, True]
-        self._cmdList['u'] = ["    - UDS shift value",1,"[shift value]", self.change_shift, True]
+        self._cmdList['a'] = Command("Analysis of captured traffic", 1, "<UDS|ISO|FRAG|ALL(defaut)>,[buffer index]", self.do_anal, True)
+        self._cmdList['u'] = Command("    - UDS shift value",1,"[shift value]", self.change_shift, True)
 
-        self._cmdList['D'] = ["Switch sniffing to a new buffer", 1, "[name]", self.new_diff, True]
-        self._cmdList['I'] = ["Print Diff between two buffers", 1, "[buffer index 1], [buffer index 2], [uniq values max]", self.print_diff, True]
-        self._cmdList['N'] = ["Print Diff between two buffers (new ID only)", 1, "[buffer index 1], [buffer index 2]", self.print_diff_id, True]
+        self._cmdList['D'] = Command("Switch sniffing to a new buffer", 1, "[name]", self.new_diff, True)
+        self._cmdList['I'] = Command("Print Diff between two buffers", 1, "[buffer index 1], [buffer index 2], [uniq values max]", self.print_diff, True)
+        self._cmdList['N'] = Command("Print Diff between two buffers (new ID only)", 1, "[buffer index 1], [buffer index 2]", self.print_diff_id, True)
 
-        self._cmdList['Y'] = ["Dump Diff in replay format", 1, "<filename>,[buffer index ,buffer index], [uniq values max]", self.print_dump_diff, True]
-        self._cmdList['y'] = ["Dump Diff in replay format (new ID)", 1, "<filename>,[buffer index 1] , [buffer index 2]", self.print_dump_diff_id, True]
-        self._cmdList['F'] = ["Search ID in all buffers", 1, "<ID>", self.search_id, True]
+        self._cmdList['Y'] = Command("Dump Diff in replay format", 1, "<filename>,[buffer index ,buffer index], [uniq values max]", self.print_dump_diff, True)
+        self._cmdList['y'] = Command("Dump Diff in replay format (new ID)", 1, "<filename>,[buffer index 1] , [buffer index 2]", self.print_dump_diff_id, True)
+        self._cmdList['F'] = Command("Search ID in all buffers", 1, "<ID>", self.search_id, True)
 
-        self._cmdList['train'] = ["STATCHECK: profiling on normal traffic (EXPEREMENTAL)", 1, "[buffer index]", self.train, True]
-        self._cmdList['check'] = ["STATCHECK: find abnormalities on 'event' traffic  (EXPEREMENTAL)", 1, "[buffer index]", self.find_ab, True]
-        self._cmdList['act'] = ["STATCHECK: find action frame  (EXPEREMENTAL)", 0, "", self.act_detect, False]
-        self._cmdList['dump_st'] = ["STATCHECK: dump abnormalities in Replay format  (EXPEREMENTAL)", 1, "<filename>", self.dump_ab, False]
+        self._cmdList['train'] = Command("STATCHECK: profiling on normal traffic (EXPEREMENTAL)", 1, "[buffer index]", self.train, True)
+        self._cmdList['check'] = Command("STATCHECK: find abnormalities on 'event' traffic  (EXPEREMENTAL)", 1, "[buffer index]", self.find_ab, True)
+        self._cmdList['act'] = Command("STATCHECK: find action frame  (EXPEREMENTAL)", 0, "", self.act_detect, False)
+        self._cmdList['dump_st'] = Command("STATCHECK: dump abnormalities in Replay format  (EXPEREMENTAL)", 1, "<filename>", self.dump_ab, False)
 
-        self._cmdList['load'] = ["Load Replay dumps from files into buffers", 1, "filename1[,filename2,...] ", self.load_rep, True]
+        self._cmdList['load'] = Command("Load Replay dumps from files into buffers", 1, "filename1[,filename2,...] ", self.load_rep, True)
 
-        self._cmdList['change'] = ["Detect changes for ECU (EXPEREMENTAL)", 1, "[buffer index][, max uniq. values]", self.show_change, True]
-        self._cmdList['detect'] = ["Detect changes for ECU by control FRAME (EXPEREMENTAL)", 1, "<ECU ID:HEX_DATA>[,buffer index]", self.show_detect, True]
-        self._cmdList['show'] = ["Show detected amount of fields for all ECU (EXPEREMENTAL)", 1, "[buffer index]", self.show_fields, True]
-        self._cmdList['fields'] = ["Show values in fields for chosen ECU (EXPEREMENTAL)", 1, "<ECU ID>[, hex|bin|int [, buffer index ]]", self.show_fields_ecu, True]
+        self._cmdList['change'] = Command("Detect changes for ECU (EXPEREMENTAL)", 1, "[buffer index][, max uniq. values]", self.show_change, True)
+        self._cmdList['detect'] = Command("Detect changes for ECU by control FRAME (EXPEREMENTAL)", 1, "<ECU ID:HEX_DATA>[,buffer index]", self.show_detect, True)
+        self._cmdList['show'] = Command("Show detected amount of fields for all ECU (EXPEREMENTAL)", 1, "[buffer index]", self.show_fields, True)
+        self._cmdList['fields'] = Command("Show values in fields for chosen ECU (EXPEREMENTAL)", 1, "<ECU ID>[, hex|bin|int [, buffer index ]]", self.show_fields_ecu, True)
 
-        self._cmdList['c'] = ["Clean table, remove buffers", 0, "", self.do_clean, True]
+        self._cmdList['c'] = Command("Clean table, remove buffers", 0, "", self.do_clean, True)
 
-        self._cmdList['i'] = ["Meta-data: add description for frames", 1, "<ID>, <data regex ASCII HEX>, <description>", self.do_add_meta_descr_data, True]
-        self._cmdList['bits'] = ["Meta-data: bits fields description", 1, "<ID>, <LEN>, <TYPE>:<LAST BIT INDEX>:<DESCRIPTION>[,...]", self.do_add_meta_bit_data, True]
-        self._cmdList['l'] = ["Load meta-data", 1, "<filename>", self.do_load_meta, True]
-        self._cmdList['z'] = ["Save meta-data", 1, "<filename>", self.do_save_meta, True]
-        self._cmdList['r'] = ["Dump buffer (if index is empty then all) in replay format", 1, " <filename>, [index]", self.do_dump_replay, True]
-        self._cmdList['d2'] = ["Dump buffer (if index is empty then all) in CSV format", 1, " <filename>, [index]", self.do_dump_csv2, True]
-        self._cmdList['d'] = ["Dump STATS for buffer (if index is empty then all) in CSV format", 1, " <filename>, [index]", self.do_dump_csv, True]
-        self._cmdList['g'] = ["Get DELAY value for gen_ping/gen_fuzz (EXPERIMENTAL)",1,"<Bus SPEED in Kb/s>", self.get_delay, True]
+        self._cmdList['i'] = Command("Meta-data: add description for frames", 1, "<ID>, <data regex ASCII HEX>, <description>", self.do_add_meta_descr_data, True)
+        self._cmdList['bits'] = Command("Meta-data: bits fields description", 1, "<ID>, <LEN>, <TYPE>:<LAST BIT INDEX>:<DESCRIPTION>[,...]", self.do_add_meta_bit_data, True)
+        self._cmdList['l'] = Command("Load meta-data", 1, "<filename>", self.do_load_meta, True)
+        self._cmdList['z'] = Command("Save meta-data", 1, "<filename>", self.do_save_meta, True)
+        self._cmdList['r'] = Command("Dump buffer (if index is empty then all) in replay format", 1, " <filename>, [index]", self.do_dump_replay, True)
+        self._cmdList['d2'] = Command("Dump buffer (if index is empty then all) in CSV format", 1, " <filename>, [index]", self.do_dump_csv2, True)
+        self._cmdList['d'] = Command("Dump STATS for buffer (if index is empty then all) in CSV format", 1, " <filename>, [index]", self.do_dump_csv, True)
+        self._cmdList['g'] = Command("Get DELAY value for gen_ping/gen_fuzz (EXPERIMENTAL)",1,"<Bus SPEED in Kb/s>", self.get_delay, True)
 
 
     def get_delay(self, def_in, speed):
@@ -746,8 +746,8 @@ class mod_stat(CANModule):
         self._train_buffer = -1
         self._index = 0
         self.data_set = {}
-        self._cmdList['act'][4] = False
-        self._cmdList['dump_st'][4] = False
+        self._cmdList['act'].is_enabled = False
+        self._cmdList['dump_st'].is_enabled = False
         return "Buffers cleaned!"
 
     # Effect (could be fuzz operation, sniff, filter or whatever)
@@ -1328,8 +1328,8 @@ class mod_stat(CANModule):
         result2 += "\n"
 
         self._rep_index = _index
-        self._cmdList['act'][4] = True
-        self._cmdList['dump_st'][4] = True
+        self._cmdList['act'].is_enabled = True
+        self._cmdList['dump_st'].is_enabled = True
 
         if not self._action.is_set():
                     self._action.set()

--- a/cantoolz/modules/simple_io.py
+++ b/cantoolz/modules/simple_io.py
@@ -24,9 +24,9 @@ class simple_io(CANModule):
     def do_init(self, params):
         self.can_buffer_read = []
         self.can_buffer_write = []
-        self._cmdList['c'] = ["Clean buffers", 0, "", self.do_start, True]
-        self._cmdList['r'] = ["Read message", 0, "", self.cmd_read, True]
-        self._cmdList['w'] = ["Write message", 1, "[0x]ID[:len]:HEX_DATA", self.cmd_write, True]
+        self._cmdList['c'] = Command("Clean buffers", 0, "", self.do_start, True)
+        self._cmdList['r'] = Command("Read message", 0, "", self.cmd_read, True)
+        self._cmdList['w'] = Command("Write message", 1, "[0x]ID[:len]:HEX_DATA", self.cmd_write, True)
 
     def get_status(self, def_in = 0):
         return "Current status: " + str(self._active) + "\nFrames to read: " + str(len(self.can_buffer_read)) + "\nFrames to write: " + str(len(self.can_buffer_write))

--- a/cantoolz/modules/uds_engine_auth_baypass.py
+++ b/cantoolz/modules/uds_engine_auth_baypass.py
@@ -22,9 +22,9 @@ class uds_engine_auth_baypass(CANModule):
         self.frames = []
 
 
-        self._cmdList['set_key'] = ["Set new key  (17 hex bytes)", 1, "<key>", self.set_key, True]
-        self._cmdList['set_vin'] = ["Set VIN", 1, "<VIN>", self.set_vin, True]
-        self._cmdList['exploit'] = ["Exploit", 0, "", self.exploit, True]
+        self._cmdList['set_key'] = Command("Set new key  (17 hex bytes)", 1, "<key>", self.set_key, True)
+        self._cmdList['set_vin'] = Command("Set VIN", 1, "<VIN>", self.set_vin, True)
+        self._cmdList['exploit'] = Command("Exploit", 0, "", self.exploit, True)
 
     def exploit(self, arg):
         i = 0

--- a/cantoolz/modules/uds_tester_ecu_engine.py
+++ b/cantoolz/modules/uds_tester_ecu_engine.py
@@ -28,9 +28,9 @@ class uds_tester_ecu_engine(CANModule):
         self.record_status = False
         self.wait_for_auth = False
 
-        self._cmdList['auth'] = ["UDS Auth", 0, "", self.control_auth, True]
-        self._cmdList['set_key'] = ["Set UDS access key", 1, "<key>", self.set_key, True]
-        self._cmdList['write_id'] = ["Write parameter (HEX)", 1, "<ident>, <data>", self.write_param, True]
+        self._cmdList['auth'] = Command("UDS Auth", 0, "", self.control_auth, True)
+        self._cmdList['set_key'] = Command("Set UDS access key", 1, "<key>", self.set_key, True)
+        self._cmdList['write_id'] = Command("Write parameter (HEX)", 1, "<ident>, <data>", self.write_param, True)
 
     def write_param(self, arg, key):
         uds_msg = UDSMessage()


### PR DESCRIPTION
Currently, a module command is a simple list with 5 (+1 optional) elements:

+ A description
+ The number of parameters
+ The description of the parameters
+ The function to call when running the command
+ A boolean specifying if the command is enabled or not
+ An optional index

However, it becomes hard to read through the code when each element is referred by its index instead of a self-explanatory name. For instance, I had to go through `cantoolz.py` to understand what the 5th parameter was (`index`).

With this Pull Request, the list is replaced by a new class `Command` with self-explanatory names. The PR also add docstrings for each abstract module functions.

I tried to keep the new Command as close to the old list to avoid massive changes.
```python
# Before
self._cmdList['g'] = ["Enable/Disable sniff mode to collect packets", 0, "", self.sniff_mode, True]
# After
self._cmdList['g'] = Command("Enable/Disable sniff mode to collect packets", 0, "", self.sniff_mode, True)
```

With the new class, instead of having the following obscure code:
```python
if in_cmd in self._cmdList:
    cmd = self._cmdList[in_cmd]
    if cmd[4]:
        if len(cmd) == 5:
            cmd.append(0)
        if lost_cmd:
            ret = cmd[3](cmd[5], lost_cmd)
        else:
            ret = cmd[3](cmd[5])
    else:
        ret = "Error: command is disabled!"
```
It is now:
```python
if in_cmd in self._cmdList:
    cmd = self._cmdList[in_cmd]
    if cmd.is_enabled:
        if parameters:
            ret = cmd.callback(cmd.index, parameters)
        else:
            ret = cmd.callback(cmd.index)
    else:
        ret = 'Error: command is disabled!'
```

The unit tests are still passing:
```bash
$ python3 unit_tests.py
# . . .
Ran 25 tests in 158.490s

OK
```

It also provides what is needed to improve the command capabilities of a module. For instance, it would become easy to replace the `num_params, desc_params` with a dictionary so that `num_params` will not be needed anymore and `desc_params` will not have to be a comma-separated string but individual strings.