### PR TITLE
Fix ISO TP padding when padding with '0'

### DIFF
--- a/cantoolz/isotp.py
+++ b/cantoolz/isotp.py
@@ -115,7 +115,7 @@ class ISOTPMessage:
         if _length < 8:
             padding_data = []
             padding_length = 0
-            if padding:
+            if padding is not None:
                 padding_data = [int(padding)] * (7 - _length)
                 padding_length = 8 - _length - 1
             can_msg_list.append(CANMessage.init_data(fid, _length + 1 + padding_length, [_length] + data[:_length] + padding_data))  # Single


### PR DESCRIPTION
When using `gen_ping.py` to brute-force the UDS services in order to discover all available UDS services, you can specify a padding so that your frame is 8 bytes long.

However, when specifying a padding of '0', in order to have something like `ID: 200; Len: 8; Data: 03 14 FF 00 00 00 00 00`, ISO TP will not pad the frame as expected and instead will create something like `ID: 200; Len: 3; Data: 03 14 FF`.

This PR fixes this bug by checking that padding is not `None` instead, allowing padding with '0'.